### PR TITLE
need label to properly version from dockerhub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM lsiobase/alpine:3.9
 
 # set version label
 ARG BUILD_DATE
+ARG VERSION
 ARG TAISUN_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="thelamer"

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -2,6 +2,7 @@ FROM lsiobase/alpine:arm64v8-3.9
 
 # set version label
 ARG BUILD_DATE
+ARG VERSION
 ARG TAISUN_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="thelamer"

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -2,6 +2,7 @@ FROM lsiobase/alpine:arm32v7-3.9
 
 # set version label
 ARG BUILD_DATE
+ARG VERSION
 ARG TAISUN_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="thelamer"


### PR DESCRIPTION
This has messed up the github releases slightly. 
Since we changed to dockerhub for the versioning this cropped up as a bug for this repo. 