### PR TITLE
compile compose to be platform specific for muslc, reduce image deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,52 @@
+FROM lsiobase/alpine:3.10 as buildstage
+
+RUN \
+ echo "**** install build deps ****" && \
+ apk add --no-cache \
+	curl \
+	g++ \
+	gcc \
+	git \
+	libc-dev \
+	libffi-dev \
+	make \
+	musl-dev \
+	openssl-dev \
+	python3 \
+	python3-dev \
+	zlib-dev
+
+RUN \
+ echo "**** build pyinstaller ****" && \
+ PYINSTALLER_VERSION=$(curl -sX GET "https://api.github.com/repos/pyinstaller/pyinstaller/releases/latest" \
+        | awk '/tag_name/{print $4;exit}' FS='[""]') && \
+ git clone --depth 1 \
+	--single-branch \
+	--branch ${PYINSTALLER_VERSION} \
+	https://github.com/pyinstaller/pyinstaller.git \
+	/tmp/pyinstaller && \
+ cd /tmp/pyinstaller/bootloader && \
+ CFLAGS="-Wno-stringop-overflow" python3 \
+	./waf configure --no-lsb all && \
+ pip3 install ..
+ 
+
+RUN \
+ echo "**** build compose ****" && \
+ cd /tmp && \
+ COMPOSE_VERSION=$(curl -sX GET "https://api.github.com/repos/docker/compose/releases/latest" \
+	| awk '/tag_name/{print $4;exit}' FS='[""]') && \
+ git clone https://github.com/docker/compose.git && \
+ cd compose && \
+ git checkout "${COMPOSE_VERSION}" && \
+ pip3 install \
+	-r requirements.txt && \
+ ./script/build/write-git-sha && \
+ pyinstaller docker-compose.spec && \
+ mv dist/docker-compose /
+
+
+# runtime stage
 FROM lsiobase/alpine:3.10
 
 # set version label
@@ -16,21 +65,16 @@ RUN \
 	make \
 	musl-dev \
 	nodejs-npm \
-	openssl-dev \
-	py-pip \
-	python-dev && \
+	openssl-dev && \
  echo "**** install runtime packages ****" && \
  apk add --no-cache \
-	nodejs \
-	docker \
-	libcap \
-	tcl \
+	docker-cli \
 	expect \
-	python2 && \
- pip install --upgrade pip && \
+	libcap \
+	nodejs \
+	tcl && \
  npm config set unsafe-perm true && \
  npm i npm@latest -g && \
- pip install docker-compose && \
  echo "**** install Taisun ****" && \
  mkdir -p \
 	/usr/src/Taisun && \
@@ -47,7 +91,9 @@ RUN \
  echo ${TAISUN_RELEASE} > /usr/src/Taisun/version && \
  echo "**** install node modules ****" && \
  npm install --prefix /usr/src/Taisun && \
+ echo "**** permissions ****" && \
  chown -R abc:abc /usr/src/Taisun && \
+ addgroup -g 100 docker && \ 
  echo "**** cleanup ****" && \
  apk del --purge \
 	build-dependencies && \
@@ -56,6 +102,9 @@ RUN \
 	/tmp/* && \
  mkdir -p \
 	/root
+
+# Docker compose
+COPY --from=buildstage /docker-compose /usr/local/bin/
 
 # add local files
 COPY root/ /

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,3 +1,52 @@
+FROM lsiobase/alpine:arm64v8-3.10 as buildstage
+
+RUN \
+ echo "**** install build deps ****" && \
+ apk add --no-cache \
+	curl \
+	g++ \
+	gcc \
+	git \
+	libc-dev \
+	libffi-dev \
+	make \
+	musl-dev \
+	openssl-dev \
+	python3 \
+	python3-dev \
+	zlib-dev
+
+RUN \
+ echo "**** build pyinstaller ****" && \
+ PYINSTALLER_VERSION=$(curl -sX GET "https://api.github.com/repos/pyinstaller/pyinstaller/releases/latest" \
+        | awk '/tag_name/{print $4;exit}' FS='[""]') && \
+ git clone --depth 1 \
+	--single-branch \
+	--branch ${PYINSTALLER_VERSION} \
+	https://github.com/pyinstaller/pyinstaller.git \
+	/tmp/pyinstaller && \
+ cd /tmp/pyinstaller/bootloader && \
+ CFLAGS="-Wno-stringop-overflow" python3 \
+	./waf configure --no-lsb all && \
+ pip3 install ..
+ 
+
+RUN \
+ echo "**** build compose ****" && \
+ cd /tmp && \
+ COMPOSE_VERSION=$(curl -sX GET "https://api.github.com/repos/docker/compose/releases/latest" \
+	| awk '/tag_name/{print $4;exit}' FS='[""]') && \
+ git clone https://github.com/docker/compose.git && \
+ cd compose && \
+ git checkout "${COMPOSE_VERSION}" && \
+ pip3 install \
+	-r requirements.txt && \
+ ./script/build/write-git-sha && \
+ pyinstaller docker-compose.spec && \
+ mv dist/docker-compose /
+
+
+# runtime stage
 FROM lsiobase/alpine:arm64v8-3.10
 
 # set version label
@@ -10,27 +59,22 @@ LABEL maintainer="thelamer"
 RUN \
  echo "**** install build packages ****" && \
  apk add --no-cache --virtual=build-dependencies \
-        curl \
-        gcc \
-        libffi-dev \
-        make \
-        musl-dev \
-        nodejs-npm \
-        openssl-dev \
-        py-pip \
-        python-dev && \
+	curl \
+	gcc \
+	libffi-dev \
+	make \
+	musl-dev \
+	nodejs-npm \
+	openssl-dev && \
  echo "**** install runtime packages ****" && \
  apk add --no-cache \
-	nodejs \
-	docker \
-	libcap \
-	tcl \
+	docker-cli \
 	expect \
-	python2 && \
- pip install --upgrade pip && \
+	libcap \
+	nodejs \
+	tcl && \
  npm config set unsafe-perm true && \
  npm i npm@latest -g && \
- pip install docker-compose && \
  echo "**** install Taisun ****" && \
  mkdir -p \
 	/usr/src/Taisun && \
@@ -47,7 +91,9 @@ RUN \
  echo ${TAISUN_RELEASE} > /usr/src/Taisun/version && \
  echo "**** install node modules ****" && \
  npm install --prefix /usr/src/Taisun && \
+ echo "**** permissions ****" && \
  chown -R abc:abc /usr/src/Taisun && \
+ addgroup -g 100 docker && \ 
  echo "**** cleanup ****" && \
  apk del --purge \
 	build-dependencies && \
@@ -57,6 +103,8 @@ RUN \
  mkdir -p \
 	/root
 
+# Docker compose
+COPY --from=buildstage /docker-compose /usr/local/bin/
 
 # add local files
 COPY root/ /

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,3 +1,52 @@
+FROM lsiobase/alpine:arm32v7-3.10 as buildstage
+
+RUN \
+ echo "**** install build deps ****" && \
+ apk add --no-cache \
+	curl \
+	g++ \
+	gcc \
+	git \
+	libc-dev \
+	libffi-dev \
+	make \
+	musl-dev \
+	openssl-dev \
+	python3 \
+	python3-dev \
+	zlib-dev
+
+RUN \
+ echo "**** build pyinstaller ****" && \
+ PYINSTALLER_VERSION=$(curl -sX GET "https://api.github.com/repos/pyinstaller/pyinstaller/releases/latest" \
+        | awk '/tag_name/{print $4;exit}' FS='[""]') && \
+ git clone --depth 1 \
+	--single-branch \
+	--branch ${PYINSTALLER_VERSION} \
+	https://github.com/pyinstaller/pyinstaller.git \
+	/tmp/pyinstaller && \
+ cd /tmp/pyinstaller/bootloader && \
+ CFLAGS="-Wno-stringop-overflow" python3 \
+	./waf configure --no-lsb all && \
+ pip3 install ..
+ 
+
+RUN \
+ echo "**** build compose ****" && \
+ cd /tmp && \
+ COMPOSE_VERSION=$(curl -sX GET "https://api.github.com/repos/docker/compose/releases/latest" \
+	| awk '/tag_name/{print $4;exit}' FS='[""]') && \
+ git clone https://github.com/docker/compose.git && \
+ cd compose && \
+ git checkout "${COMPOSE_VERSION}" && \
+ pip3 install \
+	-r requirements.txt && \
+ ./script/build/write-git-sha && \
+ pyinstaller docker-compose.spec && \
+ mv dist/docker-compose /
+
+
+# runtime stage
 FROM lsiobase/alpine:arm32v7-3.10
 
 # set version label
@@ -10,27 +59,22 @@ LABEL maintainer="thelamer"
 RUN \
  echo "**** install build packages ****" && \
  apk add --no-cache --virtual=build-dependencies \
-        curl \
-        gcc \
-        libffi-dev \
-        make \
-        musl-dev \
-        nodejs-npm \
-        openssl-dev \
-        py-pip \
-        python-dev && \
+	curl \
+	gcc \
+	libffi-dev \
+	make \
+	musl-dev \
+	nodejs-npm \
+	openssl-dev && \
  echo "**** install runtime packages ****" && \
  apk add --no-cache \
-	nodejs \
-	docker \
-	libcap \
-	tcl \
+	docker-cli \
 	expect \
-	python2 && \
- pip install --upgrade pip && \
+	libcap \
+	nodejs \
+	tcl && \
  npm config set unsafe-perm true && \
  npm i npm@latest -g && \
- pip install docker-compose && \
  echo "**** install Taisun ****" && \
  mkdir -p \
 	/usr/src/Taisun && \
@@ -47,7 +91,9 @@ RUN \
  echo ${TAISUN_RELEASE} > /usr/src/Taisun/version && \
  echo "**** install node modules ****" && \
  npm install --prefix /usr/src/Taisun && \
+ echo "**** permissions ****" && \
  chown -R abc:abc /usr/src/Taisun && \
+ addgroup -g 100 docker && \ 
  echo "**** cleanup ****" && \
  apk del --purge \
 	build-dependencies && \
@@ -56,6 +102,9 @@ RUN \
 	/tmp/* && \
  mkdir -p \
 	/root
+
+# Docker compose
+COPY --from=buildstage /docker-compose /usr/local/bin/
 
 # add local files
 COPY root/ /

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **20.07.19:** - Build compose bins from source, use minimal docker install from repos.
 * **28.06.19:** - Rebasing to alpine 3.10.
 * **30.03.19:** - Updating docker-compose build dependancies for musl libc.
 * **23.03.19:** - Switching to new Base images, shift to arm32v7 tag.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -43,6 +43,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "20.07.19:", desc: "Build compose bins from source, use minimal docker install from repos." }
   - { date: "28.06.19:", desc: "Rebasing to alpine 3.10." }
   - { date: "30.03.19:", desc: "Updating docker-compose build dependancies for musl libc." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }


### PR DESCRIPTION
Summer cleaning on this one to reduce overall footprint. 

Only need docker-cli and can package compose down to a 10 meg bin instead of tons of python3 deps by packaging wiht pyinstaller. 