### PR TITLE
update build flags for pyinstaller to support 3.6, tag them into specifc versions with args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM lsiobase/alpine:3.10 as buildstage
+FROM lsiobase/alpine:3.11 as buildstage
+
+ARG COMPOSE_VERSION=1.24.1
+ARG PYINSTALLER_VERSION=v3.6
 
 RUN \
  echo "**** install build deps ****" && \
@@ -18,31 +21,27 @@ RUN \
 
 RUN \
  echo "**** build pyinstaller ****" && \
- PYINSTALLER_VERSION=$(curl -sX GET "https://api.github.com/repos/pyinstaller/pyinstaller/releases/latest" \
-        | awk '/tag_name/{print $4;exit}' FS='[""]') && \
  git clone --depth 1 \
 	--single-branch \
 	--branch ${PYINSTALLER_VERSION} \
 	https://github.com/pyinstaller/pyinstaller.git \
 	/tmp/pyinstaller && \
  cd /tmp/pyinstaller/bootloader && \
- CFLAGS="-Wno-stringop-overflow" python3 \
+ CFLAGS="-Wno-stringop-overflow -Wno-error=stringop-truncation" python3 \
 	./waf configure --no-lsb all && \
  pip3 install ..
- 
 
 RUN \
  echo "**** build compose ****" && \
  cd /tmp && \
  git clone https://github.com/docker/compose.git && \
  cd compose && \
- git checkout 1.24.1 && \
+ git checkout ${COMPOSE_VERSION} && \
  pip3 install \
 	-r requirements.txt && \
  ./script/build/write-git-sha > compose/GITSHA && \
  pyinstaller docker-compose.spec && \
  mv dist/docker-compose /
-
 
 # runtime stage
 FROM lsiobase/alpine:3.11

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,7 @@
-FROM lsiobase/alpine:arm64v8-3.10 as buildstage
+FROM lsiobase/alpine:arm64v8-3.11 as buildstage
+
+ARG COMPOSE_VERSION=1.24.1
+ARG PYINSTALLER_VERSION=v3.6
 
 RUN \
  echo "**** install build deps ****" && \
@@ -18,31 +21,27 @@ RUN \
 
 RUN \
  echo "**** build pyinstaller ****" && \
- PYINSTALLER_VERSION=$(curl -sX GET "https://api.github.com/repos/pyinstaller/pyinstaller/releases/latest" \
-        | awk '/tag_name/{print $4;exit}' FS='[""]') && \
  git clone --depth 1 \
 	--single-branch \
 	--branch ${PYINSTALLER_VERSION} \
 	https://github.com/pyinstaller/pyinstaller.git \
 	/tmp/pyinstaller && \
  cd /tmp/pyinstaller/bootloader && \
- CFLAGS="-Wno-stringop-overflow" python3 \
+ CFLAGS="-Wno-stringop-overflow -Wno-error=stringop-truncation" python3 \
 	./waf configure --no-lsb all && \
  pip3 install ..
- 
 
 RUN \
  echo "**** build compose ****" && \
  cd /tmp && \
  git clone https://github.com/docker/compose.git && \
  cd compose && \
- git checkout 1.24.1 && \
+ git checkout ${COMPOSE_VERSION} && \
  pip3 install \
 	-r requirements.txt && \
  ./script/build/write-git-sha > compose/GITSHA && \
  pyinstaller docker-compose.spec && \
  mv dist/docker-compose /
-
 
 # runtime stage
 FROM lsiobase/alpine:arm64v8-3.11

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,7 @@
-FROM lsiobase/alpine:arm32v7-3.10 as buildstage
+FROM lsiobase/alpine:arm32v7-3.11 as buildstage
+
+ARG COMPOSE_VERSION=1.24.1
+ARG PYINSTALLER_VERSION=v3.6
 
 RUN \
  echo "**** install build deps ****" && \
@@ -18,33 +21,27 @@ RUN \
 
 RUN \
  echo "**** build pyinstaller ****" && \
- PYINSTALLER_VERSION=$(curl -sX GET "https://api.github.com/repos/pyinstaller/pyinstaller/releases/latest" \
-        | awk '/tag_name/{print $4;exit}' FS='[""]') && \
  git clone --depth 1 \
 	--single-branch \
 	--branch ${PYINSTALLER_VERSION} \
 	https://github.com/pyinstaller/pyinstaller.git \
 	/tmp/pyinstaller && \
  cd /tmp/pyinstaller/bootloader && \
- CFLAGS="-Wno-stringop-overflow" python3 \
+ CFLAGS="-Wno-stringop-overflow -Wno-error=stringop-truncation" python3 \
 	./waf configure --no-lsb all && \
  pip3 install ..
- 
 
 RUN \
  echo "**** build compose ****" && \
  cd /tmp && \
- COMPOSE_VERSION=$(curl -sX GET "https://api.github.com/repos/docker/compose/releases/latest" \
-	| awk '/tag_name/{print $4;exit}' FS='[""]') && \
  git clone https://github.com/docker/compose.git && \
  cd compose && \
- git checkout 1.24.1 && \
+ git checkout ${COMPOSE_VERSION} && \
  pip3 install \
 	-r requirements.txt && \
  ./script/build/write-git-sha > compose/GITSHA && \
  pyinstaller docker-compose.spec && \
  mv dist/docker-compose /
-
 
 # runtime stage
 FROM lsiobase/alpine:arm32v7-3.11


### PR DESCRIPTION
Build is currently busted at head due to a pyinstaller release, gets us building again. 